### PR TITLE
Add configurable dropout to HRM v2 architecture

### DIFF
--- a/config/arch/hrm_v2_params_matched.yaml
+++ b/config/arch/hrm_v2_params_matched.yaml
@@ -9,9 +9,12 @@ halt_max_steps: 16
 H_cycles: 1  # kept for compatibility
 H_layers: 8 
 
-hidden_size: 512  
+hidden_size: 512
 num_heads: 12
 expansion: 4
+
+attention_dropout: 0.0
+mlp_dropout: 0.0
 
 puzzle_emb_ndim: ${.hidden_size}
 


### PR DESCRIPTION
## Summary
- add attention and MLP dropout layers to the HRM v2 transformer block
- expose dropout hyperparameters in the hrm_v2_params_matched architecture config

## Testing
- python -m compileall models/hrm/hrm_act_v2.py

------
https://chatgpt.com/codex/tasks/task_e_68d655addd7c8324b9edc86857763831