### PR TITLE
Add checkpoint resume support to training pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,24 @@ torchrun \
   --nproc_per_node $GPUS_PER_NODE \
   --rdzv_backend c10d \
   --rdzv_endpoint $MASTER_ADDR:$MASTER_PORT \
-  pretrain.py  
+  pretrain.py
 ```
+
+### Resume training from checkpoints
+
+Training automatically saves checkpoints to `checkpoints/<project>/<run_name>/step_<N>.pt`. Each checkpoint contains the model
+weights, optimizer states, and RNG state so you can resume without losing learning-rate scheduling progress. To resume, point
+`load_checkpoint` at a specific file or set it to `latest` to load the most recent checkpoint in `checkpoint_path`:
+
+```bash
+# Resume from a specific checkpoint file
+torchrun --nproc-per-node 8 pretrain.py load_checkpoint=checkpoints/your_model/step_010000.pt
+
+# Resume using the latest checkpoint saved under the configured checkpoint_path
+torchrun --nproc-per-node 8 pretrain.py load_checkpoint=latest
+```
+
+When resuming, keep the same `checkpoint_path` so subsequent checkpoints continue the numbering sequence.
 
 
 ### Change architecture to transformer
@@ -139,7 +155,7 @@ After training, evaluate the same model with different numbers of inference step
 # save as eval_inference_steps.py
 from evaluate_trained_model import evaluate_checkpoint
 
-checkpoint = 'checkpoints/your_model/step_XXXXX'  # Update with your checkpoint
+checkpoint = 'checkpoints/your_model/step_XXXXX.pt'  # Update with your checkpoint
 data_path = 'data/arc-aug-1000'  # Your test dataset
 
 # Test different max steps
@@ -181,7 +197,7 @@ After training a model, vary how many augmentations are used at inference time. 
 ```bash
 # Evaluate the same trained model with varying augmentation counts
 python run_augmentation_ablation_eval.py \
-  --checkpoint checkpoints/your_model/step_XXXXX \
+  --checkpoint checkpoints/your_model/step_XXXXX.pt \
   --data-path data/arc-aug-1000 \
   --augmentation-counts 1,2,3,5,10,20,40,60,100,200,400,600 \
   --output-dir augmentation_eval_results \
@@ -190,7 +206,7 @@ python run_augmentation_ablation_eval.py \
 
 # For multi-GPU evaluation (recommended):
 torchrun --nproc-per-node 8 run_augmentation_ablation_eval.py \
-  --checkpoint checkpoints/your_model/step_XXXXX \
+  --checkpoint checkpoints/your_model/step_XXXXX.pt \
   --data-path data/arc-aug-1000 \
   --augmentation-counts 1,2,3,5,10,20,40,60,100,200,400,600 \
   --output-dir augmentation_eval_results

--- a/evaluate_trained_model.py
+++ b/evaluate_trained_model.py
@@ -7,13 +7,13 @@ Supports both single and multi-GPU evaluation.
 Usage:
     # Single GPU
     python evaluate_trained_model.py \
-        --checkpoint-path checkpoints/arc-aug-600/run_name/checkpoint.pt \
+        --checkpoint-path checkpoints/arc-aug-600/run_name/step_XXXXX.pt \
         --data-path data/arc-aug-1000-test \
         --output-dir eval_results/run_name_1000aug
-    
+
     # Multi-GPU
     torchrun --nproc-per-node 8 evaluate_trained_model.py \
-        --checkpoint-path checkpoints/arc-aug-600/run_name/checkpoint.pt \
+        --checkpoint-path checkpoints/arc-aug-600/run_name/step_XXXXX.pt \
         --data-path data/arc-aug-1000-test \
         --output-dir eval_results/run_name_1000aug
 """
@@ -34,11 +34,10 @@ from omegaconf import DictConfig, OmegaConf
 
 from pretrain import (
     PretrainConfig,
-    create_dataloader, 
+    create_dataloader,
     create_model,
     create_evaluators,
     evaluate,
-    load_checkpoint,
     TrainState
 )
 from utils.functions import load_model_class
@@ -207,23 +206,25 @@ def evaluate_checkpoint(
     # Load checkpoint weights
     if rank == 0:
         print(f"Loading checkpoint weights from: {checkpoint_path}")
-        
+
         # Load the checkpoint
-        checkpoint = torch.load(checkpoint_path, map_location='cpu')
-        
+        checkpoint = torch.load(checkpoint_path, map_location="cpu")
+
         # Handle different checkpoint formats
-        if 'model' in checkpoint:
-            state_dict = checkpoint['model']
-        elif 'state_dict' in checkpoint:
-            state_dict = checkpoint['state_dict']
+        if "model" in checkpoint:
+            state_dict = checkpoint["model"]
+        elif "state_dict" in checkpoint:
+            state_dict = checkpoint["state_dict"]
+        elif "model_state_dict" in checkpoint:
+            state_dict = checkpoint["model_state_dict"]
         else:
             state_dict = checkpoint
-        
+
         # Load state dict
         model.load_state_dict(state_dict, strict=True)
-        
+
         # Get step number if available
-        step = checkpoint.get('step', 0)
+        step = checkpoint.get("step", 0)
     else:
         step = 0
     


### PR DESCRIPTION
## Summary
- extend checkpoint saving to include optimizer and RNG state so training can resume mid-run
- add logic to restore checkpoints (including latest-from-directory) and update evaluation script/readme for new format

## Testing
- python -m py_compile pretrain.py evaluate_trained_model.py

------
https://chatgpt.com/codex/tasks/task_e_68d790f1d90883248c59268e6d97e233